### PR TITLE
Italian translation for info_acp_attributes.php

### DIFF
--- a/language/it/info_acp_attributes.php
+++ b/language/it/info_acp_attributes.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ *
+ * @package Quick Title Edition Extension
+ * @copyright (c) 2015 ABDev
+ * @copyright (c) 2015 PastisD
+ * @copyright (c) 2015 Geolim4 <http://geolim4.com>
+ * @copyright (c) 2015 Zoddo <zoddo.ino@gmail.com>
+ * @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
+ *
+ */
+
+// ignore
+if (!defined('IN_PHPBB'))
+{
+	exit;
+}
+
+// init lang ary, if it doesn't !
+if (empty($lang) || !is_array($lang))
+{
+	$lang = array();
+}
+
+// administration
+$lang = array_merge($lang, array(
+	'QTE_MANAGE' => 'Gestisci attributi topic',
+	'QTE_MANAGE_TITLE' => 'Attributi topic',
+	'QTE_MANAGE_EXPLAIN' => 'Qui è possibile gestire le espressioni e le icone usate come attributi topic.',
+));


### PR DESCRIPTION
Preliminary Italian translation for info_acp_attributes for Quick Title Edition extension.